### PR TITLE
Fixed coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 node_modules
 *.swp
+cov-*
+coverage

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,14 +67,6 @@ module.exports = function(grunt) {
         },
         command: 'env NODE_PATH=. ./node_modules/.bin/mocha -A -u exports --recursive test/unit/'
       },
-      accept: {
-        options: {
-          stdout: true,
-          stderr: true,
-          failOnError: true
-        },
-        command: 'env NODE_PATH=. ./node_modules/.bin/turbo --setUp=test/accept/server.js --tearDown=test/accept/server.js test/accept'
-      },
       coverage_unit: {
         options: {
           stdout: true,
@@ -83,22 +75,7 @@ module.exports = function(grunt) {
         },
         command: [
           'rm -rf coverage cov-unit',
-          'env NODE_PATH=. ./node_modules/.bin/istanbul cover --dir cov-unit ./node_modules/.bin/turbo -- test/unit',
-          './node_modules/.bin/istanbul report',
-          'echo "See html coverage at: `pwd`/coverage/lcov-report/index.html"'
-        ].join('&&')
-      },
-      coverage_accept: {
-        options: {
-          stdout: true,
-          stderr: true,
-          failOnError: true
-        },
-        command: [
-          'rm -rf coverage cov-accept',
-          'env NODE_PATH=. ./node_modules/.bin/istanbul cover --dir cov-accept ./node_modules/.bin/turbo -- --setUp=test/accept/server.js --tearDown=test/accept/server.js test/accept',
-          './node_modules/.bin/istanbul report',
-          'echo "See html coverage at: `pwd`/coverage/lcov-report/index.html"'
+          'env NODE_PATH=. ./node_modules/.bin/istanbul cover --dir cov-unit ./node_modules/.bin/_mocha -- -u exports -R spec ./test/unit/*.js'
         ].join('&&')
       }
     },
@@ -128,14 +105,10 @@ module.exports = function(grunt) {
   require('load-grunt-tasks')(grunt, {scope: 'devDependencies'});
 
   // Testing tasks
-  grunt.registerTask('test', ['shell:unit', 'shell:accept']);
-  grunt.registerTask('unit', ['env:local', 'shell:unit']);
-  grunt.registerTask('accept', ['env:local', 'shell:accept']);
+  grunt.registerTask('test', ['env:local', 'shell:unit']);
 
   // Coverate tasks
-  grunt.registerTask('coverage', ['shell:coverage_unit', 'shell:coverage_accept']);
-  grunt.registerTask('coverage-unit', ['shell:coverage_unit']);
-  grunt.registerTask('coverage-accept', ['env:local', 'shell:coverage_accept']);
+  grunt.registerTask('coverage', ['env:local', 'shell:coverage_unit']);
 
   grunt.registerTask('analysis', ['plato:src', 'open:platoReport']);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "application.js",
   "scripts": {
     "start": "node application.js",
-    "test": "grunt unit"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",
@@ -27,6 +27,7 @@
     "async": "1.5.0"
   },
   "devDependencies": {
+    "grunt": "^0.4.0",
     "grunt-concurrent": "latest",
     "grunt-contrib-watch": "latest",
     "grunt-env": "~0.4.1",


### PR DESCRIPTION
# Motivation
https://issues.jboss.org/browse/RHMAP-14680

# Changes
- replaced turbo with mocha for code coverage
- added grunt to dev-dependencies (needed with npm version >=3)

# Steps to verify
- `npm install`
- then these commands should work:
  - `grunt serve`
  - `grunt test`
  - `grunt coverage`